### PR TITLE
Allow worker to handle reset requests immediately

### DIFF
--- a/frontend/worker.js
+++ b/frontend/worker.js
@@ -75,11 +75,11 @@ const process = async ({ image, kernel, normalize, delay }) => {
   postMessage({ type: "done" });
 };
 
-self.onmessage = async (event) => {
+self.onmessage = (event) => {
   const { type } = event.data;
   switch (type) {
     case "start":
-      await process(event.data);
+      process(event.data);
       break;
     case "pause":
       paused = true;


### PR DESCRIPTION
## Summary
- stop awaiting the convolution process inside the worker message handler
- allow reset messages to be processed immediately so ongoing work is cancelled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9547e11d88328ac63ab0c47c3768c