### PR TITLE
Handle reset cancellation when interval is zero

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,8 +31,14 @@
             <input type="checkbox" id="normalize-toggle" checked />
           </label>
           <label>
-            速度 (ms)
-            <input type="number" id="speed-input" min="0" step="10" value="50" />
+            インターバル (ms)
+            <input
+              type="number"
+              id="interval-input"
+              min="0"
+              step="10"
+              value="50"
+            />
           </label>
         </div>
         <div class="preset-buttons">

--- a/frontend/worker.js
+++ b/frontend/worker.js
@@ -23,7 +23,7 @@ const waitWhilePaused = async () => {
   }
 };
 
-const process = async ({ image, kernel, normalize, delay }) => {
+const process = async ({ image, kernel, normalize, delay, taskId }) => {
   const { width, height, data } = image;
   const src = new Uint8ClampedArray(data);
   const grayscale = computeGrayscale(src, width, height);
@@ -37,17 +37,17 @@ const process = async ({ image, kernel, normalize, delay }) => {
 
   for (let y = 0; y < height; y += 1) {
     if (cancelled) {
-      postMessage({ type: "cancelled" });
+      postMessage({ type: "cancelled", taskId });
       return;
     }
     for (let x = 0; x < width; x += 1) {
       if (cancelled) {
-        postMessage({ type: "cancelled" });
+        postMessage({ type: "cancelled", taskId });
         return;
       }
       await waitWhilePaused();
       if (cancelled) {
-        postMessage({ type: "cancelled" });
+        postMessage({ type: "cancelled", taskId });
         return;
       }
 
@@ -65,14 +65,14 @@ const process = async ({ image, kernel, normalize, delay }) => {
       const value = clamp(Math.round(acc / divisor), 0, 255);
       const idx = (y * width + x) * 4;
 
-      postMessage({ type: "progress", idx, value, x, y });
+      postMessage({ type: "progress", idx, value, x, y, taskId });
       if (delay > 0) {
         await sleep(delay);
       }
     }
   }
 
-  postMessage({ type: "done" });
+  postMessage({ type: "done", taskId });
 };
 
 self.onmessage = (event) => {


### PR DESCRIPTION
## Summary
- add task tracking between the UI and worker so reset stops processing immediately and prevents stale updates
- clear the rendered result buffer when resetting to remove any previous pixels
- rename the speed control to "インターバル" to clarify that the value represents the delay between steps

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d95adb4e648328af348a36d0cb360a